### PR TITLE
Simultaneous multi device.

### DIFF
--- a/config
+++ b/config
@@ -1,3 +1,0 @@
-/dev/input/by-id/put-your-device-name-here
-default.json
-settings.json

--- a/devices/event-example.json.example
+++ b/devices/event-example.json.example
@@ -1,0 +1,7 @@
+{
+	"initial_layer": "default.json",
+	"event": "a file name in /dev/input/",
+	"udev_tests": [
+		"some strings for udev rule device identification"
+	]
+}

--- a/devices/event-example.json.example
+++ b/devices/event-example.json.example
@@ -1,7 +1,0 @@
-{
-	"initial_layer": "default.json",
-	"event": "a file name in /dev/input/",
-	"udev_tests": [
-		"some strings for udev rule device identification"
-	]
-}

--- a/keebie.py
+++ b/keebie.py
@@ -25,11 +25,12 @@ def dprint(*args, **kwargs): # Print debug info (or don't)
 
 # Global vars
 
-templateDataDir = "/usr/share/keebie/" # Path where default user configuration files are installed
+installDataDir = "/usr/share/keebie/" # Path where default user configuration files and more and are installed
 dataDir = os.path.expanduser("~") + "/.config/keebie/" # Path where user configuration files should be stored
 dprint(dataDir)
 
 layerDir = dataDir + "layers/" # Cache the full path to the /layers directory
+deviceDir = dataDir + "devices/" # Cache the full path to the /devices directory
 scriptDir = dataDir + "scripts/" # Cache the full path to the /scripts directory
 
 
@@ -39,16 +40,11 @@ scriptDir = dataDir + "scripts/" # Cache the full path to the /scripts directory
 def signal_handler(signal, frame):
     end()
 
-def end(): # Properly close the device file and exit the script
-    close(device)
-    sys.exit(0)
-
-def close(self): # try to close the device file gracefully
-    if self.fd > -1:
-        try:
-            os.close(self.fd)
-        finally:
-            self.fd = -1
+def end(ungrab=True): # Properly close the device file and exit the script
+    if ungrab == True: # If we need to clean up grabbed macroDevices
+        ungrabMacroDevices() # Ungrab all devices
+        closeDevices() # Cleanly close all devices
+    sys.exit(0) # Exit without error
 
 
 
@@ -56,7 +52,9 @@ def close(self): # try to close the device file gracefully
 
 class keyLedger():
     """A class for finding all keys pressed at any time."""
-    def __init__(self):
+    def __init__(self, name="unnamed ledger"):
+        self.name = name # Name of the ledger for debugging
+
         self.keysList = [] # A list of keycodes of keys being held as strings
         self.newKeysList = [] # A list of keycodes of keys that were newly held when update() was last run as strings
         self.freshKeysList = [] # A list of keycodes of keys being held as strings that is empty unless a new key was pressed when update() was last run
@@ -71,28 +69,31 @@ class keyLedger():
             keycode = keyEvent.keycode # Cache value that we are about to use a lot
             keystate = keyEvent.keystate
 
+            if type(keycode) == list: # If the keycode is a list of keycodes (it can happen) 
+                keycode = keycode[0] # Select the first one
+
             if keystate == keyEvent.key_down or keystate == keyEvent.key_hold: # If a new key has been pressed or a key we might have missed the down event for is being held
                 if not keycode in self.keysList: # If this key (which is held) is not in our list of keys that are held
-                    dprint(f"New key tracked: {keycode}")
+                    dprint(f"{self.name}) New key tracked: {keycode}")
                     self.keysList += [keycode, ] # Add list of our (one) keycode to list of held keys
                     self.newKeysList += [keycode, ] # and to our list of newly held keys
 
             elif keystate == keyEvent.key_up: # If a key has been released
                 if keycode in self.keysList: # And if we have that key marked as held
-                    dprint(f"Tracked key {keycode} released.")
+                    dprint(f"{self.name}) Tracked key {keycode} released.")
                     self.keysList.remove(keycode) # Then we remove it from our list of held keys
 
                 else:
-                    print(f"Untracked key {keycode} released.") # If you see this that means we missed a key press, bad news. (But not fatal.)
+                    print(f"{self.name}) Untracked key {keycode} released.") # If you see this that means we missed a key press, bad news. (But not fatal.)
 
-            if settings["multiKeyMode"] == "combination":
-                self.keysList.sort()
+            if settings["multiKeyMode"] == "combination": # If running in combination mode
+                self.keysList.sort() # Sort key lists deterministically
                 self.newKeysList.sort()
 
             if not self.newKeysList == []: # If new keys have pressed
                 self.freshKeysList = self.keysList # Set fresh keys equal to helf keys
-                dprint(f"New keys are: {self.newKeysList}") # Print debug info
-                dprint(f"Fresh keys are: {self.freshKeysList}")
+                dprint(f"{self.name}) New keys are: {self.newKeysList}") # Print debug info
+                dprint(f"{self.name}) Fresh keys are: {self.freshKeysList}")
 
     def getList(self, returnType = 0):
         """Returns the list of held keys in different forms based on returnType.
@@ -171,23 +172,209 @@ class keyLedger():
 
 
 
-# Config file
+# Macro device
 
-def config(): # Open the config file and return a list of it's lines with leading and trailing spaces striped
-    f = open(dataDir + "config","r") # Opens config file.
+class macroDevice():
+    """A class for managing devices."""
+    def __init__(self, deviceJson):
+        self.name = deviceJson.split(".json")[0] # Name of device for debugging
 
-    if f.mode =='r':
-        config = f.read().splitlines()
-        for confLine in range(0, len(config)) : # Strip leading and trailing whitespaces from each line of the config
-            config[confLine] = config[confLine].strip() 
-        return config
+        jsonData = readJson(deviceJson, deviceDir) # Cache the data held in the device json file
+        self.initialLayer = jsonData["initial_layer"] # Layer for the device the start on
+        self.eventFile = "/dev/input/" + jsonData["event"] # The input event file
+        self.udevTests = jsonData["udev_tests"] # Strings for udev matching
 
-def writeConfig(lineNum, data): # Writes some data to a line of the config file
-    lines = open(dataDir + 'config', 'r').readlines()
-    lines[lineNum] = data.strip() + "\n" # Ensure the data we are write will not interfere later lines
-    out = open(dataDir + 'config', 'w')
-    out.writelines(lines)
-    out.close()
+        self.currentLayer = self.initialLayer # Layer this device is currently on
+        self.ledger = keyLedger(self.name) # A keyLedger to track input events on his devicet
+        self.device = None # will be an InputEvent instance
+
+    def addUdevRule(self, priority = 85):
+        """Generate a udev rule for this device."""
+        path = f"{priority}-keebie-{self.name}" # Name of the file for the rule (file extension added by the script)
+        rule = ""
+
+        for test in self.udevTests: # For all the udev tests
+            rule += test + ", " # Add them together with commas
+            dprint(rule)
+
+        subprocess.run(["sudo", "sh", installDataDir + "/setup_tools/udevRule.sh", rule, path]) # Run the udev setup script with sudo
+
+    def grabDevice(self):
+        """Grab the device and set self.device to the grabbed device."""
+        print("grabbing device " + self.name)
+        self.device = InputDevice(self.eventFile) # Set self.device to the device of self.eventFile
+        self.device.grab() # Grab the device
+
+        self.setLeds() # Set the leds based on the current layer
+
+    def ungrabDevice(self):
+        """Ungrab the device."""
+        print("ungrabbing device " + self.name)
+        self.device.ungrab() # Do the thing that got said twice
+
+    def close(self):
+        """Try to close the device file gracefully."""
+        print("closing device " + self.name)
+        if self.device.fd > -1:
+            try:
+                os.close(self.device.fd)
+            finally:
+                self.device.fd = -1
+
+    def read(self, process=True):
+        """Read all queued events (if any), update the ledger, and process the keycodes (or don't)."""
+        try: # Try to...
+            for event in self.device.read(): # Read queued events from the device
+                self.ledger.update(event) # Update the key ledger
+                if process == True: # If we are processing the ledger
+                    self.processLedger() # Process the newly updated ledger
+
+        except BlockingIOError: # If no events are available
+            pass
+
+    def setLeds(self):
+        """Set device leds bassed on current layer."""
+        if "leds" in readJson(self.currentLayer): # If the current layer specifies LEDs
+            leds = self.device.capabilities()[17] # Get a list of LEDs the device has
+
+            onLeds = readJson(self.currentLayer)["leds"] # Get a list of LEDs to turn on
+            dprint(f"device {self.name} setting leds {onLeds} on")
+
+            for led in leds: # For all LEDs on the board
+                if led in onLeds: # If the LED is to be set on
+                    self.device.set_led(led, 1) # Set it on
+                else:
+                    self.device.set_led(led, 0) # Set it off
+        else:
+            print(f"Layer {readJson(self.currentLayer)} has no leds property, writing empty")
+            writeJson(self.currentLayer, {"leds": []}) # Write an empty list for LEDs into the current layer
+            leds = self.device.capabilities()[17] # Get a list of LEDs the device has
+
+            for led in leds: # For all LEDs on the board
+                self.device.set_led(led, 0) # Set it off
+
+    def processLedger(self):
+        """Given a keycode that might be in the current layer json file, check if it is and execute the appropriate commands"""
+        keycode = self.ledger.getFresh(1) # Get a string of fresh keys
+        if keycode == "": # If there are no fresh keys
+            return
+        
+        dprint(f"{self.name} is processing {keycode} in layer {self.currentLayer}") # Print debug info
+
+        if keycode in readJson(self.currentLayer): # If the keycode is in our current layer's json file
+            value = readJson(self.currentLayer)[keycode] # Get the instructions associated with the keycode
+            value = parseVars(value, self.currentLayer) # Parse any varables that may appear in the command
+
+            if value.startswith("layer:"): # If value is a layerswitch command
+                if os.path.exists(layerDir+value.split(':')[-1] + ".json") == False: # If the layer has no json file
+                    createLayer(value.split(':')[-1]+".json") # Create one
+                    print("Created layer file: " + value.split(':')[-1]+".json") # Notify the user
+                    self.currentLayer = value.split(':')[-1] + ".json" # Switch to our new layer file
+                    print("Switched to layer file: " + value.split(':')[-1] + ".json") # Notify the user
+
+                else:
+                    self.currentLayer = value.split(':')[-1] + ".json" # Set self.current layer to the target layer
+                    print("Switched to layer file: " + value.split(':')[-1] + ".json") # Notify the user
+
+                self.setLeds() # Set LEDs based on the new current layer
+
+            else:
+                if value.strip().endswith("&") == False and settings["forceBackground"]: # If value is not set in run in the background and our settings say to force running in the background
+                    value += " &" # Force running in the background
+                    
+                if value.strip().endswith("&") == False and settings["backgroundInversion"]: # If value is not set to run in the background and our settings say to invert background mode
+                    value += " &" # Force running in the background
+                
+                elif value.strip().endswith("&") and settings["backgroundInversion"]: # Else if value is set to run in the background and our settings say to invert background mode
+                    value = value.rstrip(" &") # Remove all spaces and &s from the end of value, there might be a better way but this is the best I've got
+
+                scriptTypes = { # A dict of script types and thier interpreters with a trailing space
+                    "script": "bash ",
+                    "py": "python ",
+                    "py2": "python2 ",
+                    "py3": "python3 ",
+                    "exec": "",
+                }
+
+                isScript = False # If the value is a script
+
+                for scriptType in scriptTypes.keys(): # For recognized script types
+                    if value.startswith(scriptType + ":"): # Check if value is one of said script types
+                        print(f"Executing {scriptTypes[scriptType]}script {value.split(':')[-1]}") # Notify the user we re running a script
+                        value = scriptTypes[scriptType] + scriptDir + value.split(':')[-1] # Set value to executable format
+                        isScript = True # Set that this is a script
+                        break # Break the loop
+                
+                if isScript == False: # If this is not a script (i.e. it is a shell command)
+                    print(keycode+": "+value) # Notify the user of the command
+                
+                os.system(value) # Execute value
+
+    def clearLedger(self):
+        """Clear this devices ledger."""
+        try: # Try to...
+            for event in self.device.read(): # For all queued events
+                pass # Completely ignore them
+        
+        except BlockingIOError: # If there arn't any queued events
+            pass # Ignore that too
+        
+        self.ledger = keyLedger(self.name) # Reset the ledger
+
+
+macroDeviceList = [] # List of macroDevice instances
+
+standardLeds = { # A dict of standard LED ids and thier names
+    0: "num lock",
+    1: "caps lock",
+    2: "scroll lock",
+}
+
+def setupMacroDevices():
+    """Setup a macroDevice instance based on the contents of deviceDir."""
+    global macroDeviceList # Globalize macroDeviceList
+    deviceJsonList = [deviceJson for deviceJson in os.listdir(deviceDir) if os.path.splitext(deviceJson)[1] == ".json"] # Get list of json files in deviceDir
+    
+    dprint(deviceJsonList) # Print debug info
+
+    for deviceJson in deviceJsonList: # For all json files in deviceDir
+        macroDeviceList += [macroDevice(deviceJson), ] # Setup a macroDevice instance for all files and save them to macroDeviceList
+
+def grabMacroDevices():
+    """Grab all devices with macroDevices."""
+    for device in macroDeviceList:
+        device.grabDevice()
+
+def ungrabMacroDevices():
+    """Ungrab all devices with macroDevices."""
+    for device in macroDeviceList:
+        device.ungrabDevice()
+
+def closeDevices():
+    """Close all devices."""
+    for device in macroDeviceList:
+        device.close()
+
+def mergeDeviceLedgers():
+    """Merge the key ledgers of all macroDevices into one and return it."""
+    returnLedger = keyLedger() # Create an empty key ledger
+    
+    for device in macroDeviceList: # For all macroDevices
+        returnLedger.keysList += device.ledger.keysList # Add the devices held keys to the retunrn ledger
+        returnLedger.newKeysList += device.ledger.newKeysList # Add the devices new keys to the retunrn ledger
+        returnLedger.freshKeysList += device.ledger.freshKeysList # Add the devices fresh keys to the retunrn ledger
+
+    return returnLedger # Return the ledger we built
+
+def clearDeviceLedgers():
+    """Clear all device ledgers."""
+    for device in macroDeviceList:
+        device.clearLedger()
+
+def readDevices(process=True):
+    """Read and optionally process all devices events."""
+    for device in macroDeviceList:
+        device.read(process)
 
 
 
@@ -232,10 +419,7 @@ def popJson(filename, key, dir = layerDir): # Removes the key key and it's value
 # Layer file
 
 def createLayer(filename): # Creates a new layer with a given filename
-    basedata = {"KEY_ESC": "layer:default", "leds": []}
-
-    with open(layerDir+filename, 'w+') as outfile:
-        json.dump(basedata, outfile, indent=3)
+    shutil.copyfile(installDataDir + "/data/layers/default.json", layerDir + filename) # Copy the provided default layer file from installedDataDir to specified filename
 
 
 
@@ -244,115 +428,42 @@ def createLayer(filename): # Creates a new layer with a given filename
 settings = { # A dict of settings to be used across the script
     "multiKeyMode": "combination",
     "forceBackground": False,
-    "backgroundInversion": False
+    "backgroundInversion": False,
+	"loopDelay": 0.0167,
 }
 
-settingsPossible = { # A dict of lists of valid values for each setting
+settingsPossible = { # A dict of lists of valid values for each setting (or if first element is type then list of acceptable types in descending priority)
     "multiKeyMode": ["combination", "sequence"],
     "forceBackground": [True, False],
-    "backgroundInversion": [True, False]
+    "backgroundInversion": [True, False],
+	"loopDelay": [type, float, int],
 }
 
 def getSettings(): # Reads the json file specified on the third line of config and sets the values of settings based on it's contents
-    print(f"Loading settings from {config()[2]}") # Notify the user we are getting settings and tell them the file we are using to do so
+    print(f"Loading settings from {dataDir}/settings.json") # Notify the user we are getting settings and tell them the file we are using to do so
 
-    settingsFile = readJson(config()[2], dataDir) # Get a dict of the keys and values in our settings file
+    settingsFile = readJson("settings.json", dataDir) # Get a dict of the keys and values in our settings file
     for setting in settings.keys(): # For every setting we expect to be in our settings file
-        if settingsFile[setting] in settingsPossible[setting]: # If the value in our settings file is valid
-            dprint(f"Found valid value: \"{settingsFile[setting]}\" for setting: \"{setting}\"")
-            settings[setting] = settingsFile[setting] # Write it into our settins
-
-        else :
-            print(f"Value: \"{settingsFile[setting]}\" for setting: \"{setting}\" is invalid, defaulting to {settings[setting]}") # Warn the user of invalid settings in the settings file
-            
-    dprint(f"Settings are {settings}") # Tell the user the settings we ended up with
-
-
-
-# LEDs
-
-def setLeds(onLeds): # Sets the passed LEDs on (and any others off)
-    leds = device.capabilities()[17] # Get a list of LEDs the device has
-
-    for led in leds: # For all LEDs on the board
-        if led in onLeds: # If the LED is to be set on
-            device.set_led(led, 1) # Set it on
+        if type == settingsPossible[setting][0]: # If first element is type
+            if type(settingsFile[setting]) in settingsPossible[setting]: # If the value in our settings file is valid
+                dprint(f"Found valid typed value: \"{type(settingsFile[setting])}\" for setting: \"{setting}\"")
+                settings[setting] = settingsFile[setting] # Write it into our settings
+            else :
+                print(f"Value: \"{settingsFile[setting]}\" for setting: \"{setting}\" is of invalid type, defaulting to {settings[setting]}") # Warn the user of invalid settings in the settings file
         else:
-            device.set_led(led, 0) # Set it off
+            if settingsFile[setting] in settingsPossible[setting]: # If the value in our settings file is valid
+                dprint(f"Found valid value: \"{settingsFile[setting]}\" for setting: \"{setting}\"")
+                settings[setting] = settingsFile[setting] # Write it into our settings
+            else :
+                print(f"Value: \"{settingsFile[setting]}\" for setting: \"{setting}\" is invalid, defaulting to {settings[setting]}") # Warn the user of invalid settings in the settings file
+
+    dprint(f"Settings are {settings}") # Debug info
 
 
 
 # Keypress processing
 
-def processKeycode(keycode): # Given a keycode that might be in the layer json file, check if it is and execute the appropriate commands
-    if keycode in readJson(config()[1]): # If the keycode is in our layer's json file
-        value = readJson(config()[1])[keycode] # Get the instructions associated with the keycode
-        value = parseVars(value) # Parse any varables that may appear in the command
-
-        if value.startswith("layer:"): # If value is a layerswitch command
-            if os.path.exists(layerDir+value.split(':')[-1] + ".json") == False: #if the layer has no json file
-                createLayer(value.split(':')[-1]+".json") # Create one
-                print("Created layer file: " + value.split(':')[-1]+".json") # Notify the user
-                writeConfig(1, value.split(':')[-1] + ".json") # Switch to our new layer file
-                print("Switched to layer file: " + value.split(':')[-1] + ".json") # Notify the user
-
-            else:
-                writeConfig(1, value.split(':')[-1] + ".json") # Switch the layer's json into our config
-                print("Switched to layer file: " + value.split(':')[-1] + ".json") # Notify the user
-
-            if "leds" in readJson(config()[1]):
-                setLeds(readJson(config()[1])["leds"])
-            else:
-                print(f"Layer {readJson(config()[1])} has no leds property, writing empty")
-                writeJson(config()[1], {"leds": []})
-                setLeds([])
-
-        if value.strip().endswith("&") == False and settings["forceBackground"]: # If value is not set in run in the background and our settings say to force running in the background
-            value += " &" # Force running in the background
-            
-        if value.strip().endswith("&") == False and settings["backgroundInversion"]: # If value is not set to run in the background and our settings say to invert background mode
-            value += " &" # Force running in the background
-        
-        elif value.strip().endswith("&") and settings["backgroundInversion"]: # Else if value is set to run in the background and our settings say to invert background mode
-            value = value.rstrip(" &") # Remove all spaces and &s from the end of value, there might be a better way but this is the best I've got
-
-        if value.startswith("layer:"): # If value is a layerswitch command
-            pass
-
-        elif value.startswith("script:"): # If value is a bash file
-            print("Executing bash script: " + value.split(':')[-1])
-            os.system('bash ' + scriptDir + value.split(':')[-1])
-
-        elif value.startswith("py:"): # If value is a generic python file
-            print("Executing python script: " + value.split(':')[-1])
-            os.system('python ' + scriptDir + value.split(':')[-1])
-
-        elif value.startswith("py2:"): # If value is a python2 file
-            print("Executing python2 script: " + value.split(':')[-1])
-            os.system('python2 ' + scriptDir + value.split(':')[-1])
-
-        elif value.startswith("py3:"): # If value is a python3 file
-            print("Executing python3 script: " + value.split(':')[-1])
-            os.system('python3 ' + scriptDir + value.split(':')[-1])
-        
-        elif value.startswith("exec:"): # If value is a generic executable
-            print("Executing file: " + value.split(':')[-1])
-            os.system(scriptDir + value.split(':')[-1])
-        
-        else: # If value is a shell command
-            print(keycode+": "+value)
-            os.system(value)
-
-def keebLoop(): # Reading the keyboard
-    signal.signal(signal.SIGINT, signal_handler)
-    ledger = keyLedger() # Reset the keyLedger
-
-    for event in device.read_loop(): # Start infinitely geting events from our keyboard
-        ledger.update(event) # Update the keyLedger with those events
-
-        processKeycode(ledger.getFresh(1)) # Check if ledger.freshKeysList matches a command in our layer's json file
-
-def parseVars(commandStr): # Given a command from the layer json file replace vars with their values and return the string
+def parseVars(commandStr, layer): # Given a command from the layer json file replace vars with their values and return the string
     # Vars we will need in the loop
     returnStr = "" # The string to be retuned
     escaped = False # If we previously encountered an escape char
@@ -377,7 +488,7 @@ def parseVars(commandStr): # Given a command from the layer json file replace va
 
         if inVar == True and char == varChars[1] : # If we are in a varable and char ends it parse the varables value, add it to returnStr if valid, and reset inVar and varName
             try :
-                returnStr += readJson(config()[1])["vars"][varName]
+                returnStr += readJson(layer)["vars"][varName]
             except KeyError :
                 print(f"unknown var {varName} in command {commandStr}, skiping command")
                 return ""
@@ -420,7 +531,7 @@ def detectKeyboard(): # Detect what file a keypress is coming from
         dev = subprocess.check_output("inotifywatch /dev/input/by-id/* -t 1 2>&1 | grep /dev/input/by-id/ | awk 'NF{ print $NF }'", shell=True ).decode('utf-8').strip()
     return dev
 
-def addKey(key = None, command = None, keycodeTimeout = 1): # Shell for adding new macros
+def addKey(layer, key = None, command = None, keycodeTimeout = 1): # Shell for adding new macros
     ledger = keyLedger() # Reset the keyLedger
 
     if key == None and command == None:
@@ -436,9 +547,9 @@ def addKey(key = None, command = None, keycodeTimeout = 1): # Shell for adding n
                 createLayer(command.split(':')[-1]+".json") # If not create it
                 print("Created layer file: " + command.split(':')[-1]+".json") # And notify the user
 
-                print("LEDs detected on your keyboard:")
-                for led in device.capabilities(verbose=True)[("EV_LED", 17)]: # For all LEDs on the board
-                    print(f"-{led[1]}: {led[0]}") # List it
+                print("standard LEDs:")
+                for led in standardLeds.items(): # For all LEDs on most boards
+                    print(f"-{led[0]}: {led[1]}") # List it
 
                 onLeds = input("Please choose what LEDs should be enable on this layer (comma and/or space separated list)") # Prompt the user for a list of LED numbers
                 onLeds = onLeds.replace(",", " ").split() # Split the input list
@@ -455,34 +566,25 @@ def addKey(key = None, command = None, keycodeTimeout = 1): # Shell for adding n
         loopStartTime = None
         signal.signal(signal.SIGINT, signal_handler)
 
-        try: # Try to...
-            for event in device.read(): # For any backlogged events from the board
-                ledger.update(event) # process it
+        clearDeviceLedgers() # Clear all device ledgers
 
-        except BlockingIOError: # If no events are currently available
-            pass
-
+        started = False # Whether the timer is started
         while True: # Start an endless loop
-            try: # Try to...
-                for event in device.read(): # For all event currently available
-                    if loopStartTime == None: # If we havn't started timing yet (i.e. if the user hasn't pressed any keys yet)
-                        loopStartTime = time.time() # Start timing
-
-                    ledger.update(event) # Keep updating the keyLedger with every new input
-            
-            except BlockingIOError: # If no events are currently available
-                pass
+            readDevices(False) # Read all devices (but don't process keycodes)
+            if started == False and not mergeDeviceLedgers().getList(0) == []: # If the timer hasn't started yet and keys are being pressed
+                started = True # Start the timer
+                loopStartTime = time.time() # Set time stamp for comparison
 
             if not loopStartTime == None and not time.time() - loopStartTime < keycodeTimeout: # Unless the time runs out
                 break # Then we break the loop    
 
-        key = ledger.getList(1)
+        key = mergeDeviceLedgers().getList(1)
 
     inp = input(f"Assign {command} to [{key}]? [Y/n] ") # Ask the user if we (and they) got the command and binding right
     if inp == 'Y' or inp == '': # If we did 
         newMacro = {}
         newMacro[key] = command
-        writeJson(config()[1], newMacro) # Write the binding into our layer json file
+        writeJson(layer, newMacro) # Write the binding into our layer json file
         print(newMacro) # And print it back
 
     else: # If we didn't
@@ -492,12 +594,12 @@ def addKey(key = None, command = None, keycodeTimeout = 1): # Shell for adding n
         rep = input("Would you like to add another Macro? [Y/n] ") # Offer the user to add another binding
 
         if rep == 'Y' or rep == '': # If they say yes
-            addKey() # Restart the shell
+            addKey(layer) # Restart the shell
 
         end()
 
 def editSettings(): # Shell for editing settings
-    settingsFile = readJson(config()[2], dataDir) # Get a dict of the keys and values in our settings file
+    settingsFile = readJson("settings.json", dataDir) # Get a dict of the keys and values in our settings file
     
     settingsList = [] # Create a list for key-value pairs of settings 
     for setting in settings.items(): # For every key-value pair in our settings dict
@@ -510,44 +612,74 @@ def editSettings(): # Shell for editing settings
     selection = input("Please make you selection: ") # Take the users input as to which setting they wish to edit
     
     try: # Try to...
-        intSelection= int(selection) # Comvert the users input from str to int
-        if intSelection in range(1, len(settingsList) + 1): # If the users input corresponds to a listed setting
-            settingSelected = settingsList[int(selection) - 1][0] # Store the selected setting's name
-            print(f"Editing item \"{settingSelected}\"") # Tell the user we are thier selection
-        
-        else: # If the users input does not correspond to a listed setting
-            print("Input out of range, exiting...") # Tell the user we are exiting
-            end() # And do so
-
-    except ValueError: # If the conversion to int fails
-        print("Exiting...") # Tell the user we are exiting
-        end() # And do so
-
-    print(f"Choose one of {settingSelected}\'s possible values.") # Ask the user to choose which value they want to assign to their selected setting
-    for valueIndex in range(0, len(settingsPossible[settingSelected])): # For the index number of every valid value of the users selected setting
-        print(f"-{valueIndex + 1}: {settingsPossible[settingSelected][valueIndex]}", end = "") # Print an entry for every valid value, as well as a number associate, with no newline
-        if settingsPossible[settingSelected][valueIndex] == settings[settingSelected]: # If a value is the current value of the selected setting
-            print("   [current]") # Tell the user and add a newline
-
-        else:
-            print() # Add a newline
-
-    selection = input("Please make you selection: ") # Take the users input as to which value they want to assign to their selected setting
-
-    try: # Try to...
         intSelection = int(selection) # Convert the users input from str to int
-        if intSelection in range(1, len(settingsPossible[settingSelected]) + 1): # If the users input corresponds to a listed value
-            valueSelected = settingsPossible[settingSelected][int(selection) - 1] # Store the selected value
-            writeJson(config()[2], {settingSelected: valueSelected}, dataDir) # Write it into our settings json file
-            print(f"Set \"{settingSelected}\" to \"{valueSelected}\"") # And tell the user we have done so
-        
-        else: # If the users input does not correspond to a listed value
-            print("Input out of range, exiting...") # Tell the user we are exiting
-            end() # And do so
-
+    
     except ValueError: # If the conversion to int fails
         print("Exiting...") # Tell the user we are exiting
-        end() # And do so
+        end(False) # And do so
+
+    if intSelection in range(1, len(settingsList) + 1): # If the users input corresponds to a listed setting
+        settingSelected = settingsList[int(selection) - 1][0] # Store the selected setting's name
+        print(f"Editing item \"{settingSelected}\"") # Tell the user we are thier selection
+    
+    else: # If the users input does not correspond to a listed setting
+        print("Input out of range, exiting...") # Tell the user we are exiting
+        end(False) # And do so
+
+    if type == settingsPossible[settingSelected][0]: # If first element of settingsPossible is type
+        print(f"Enter a value {settingSelected} that is of one of these types.")
+        for valueIndex in range(1, len(settingsPossible[settingSelected])): # For the index number of every valid type of the users selected setting
+            print("- " + settingsPossible[settingSelected][valueIndex].__name__) # Print an entry for every valid type
+            
+        selection = input("Please enter a value: ") # Prompt the user for input
+
+        if selection == "": # If none is provided
+            print("Exiting...")
+            end(False) # Exit
+
+        for typePossible in settingsPossible[settingSelected]: # For all valid types
+            dprint(typePossible)
+            if typePossible == type: # If it is type
+                continue
+            try: # Try to...
+                selection = typePossible(selection) # Cast the users input to the type
+                break
+            except ValueError: # If casting fails
+                pass
+        
+        if type(selection) in settingsPossible[settingSelected]: # If we have successfully casted to a valid type
+            writeJson("settings.json", {settingSelected: selection}, dataDir) # Write the setting into the settings file
+            print(f"Set \"{settingSelected}\" to \"{selection}\"")
+        else:
+            print("Input can't be casted to a supported type, exiting...") # Complain about the bad input
+            end(False) # And exit
+
+    else:
+        print(f"Choose one of {settingSelected}\'s possible values.") # Ask the user to choose which value they want to assign to their selected setting
+        for valueIndex in range(0, len(settingsPossible[settingSelected])): # For the index number of every valid value of the users selected setting
+            print(f"-{valueIndex + 1}: {settingsPossible[settingSelected][valueIndex]}", end = "") # Print an entry for every valid value, as well as a number associate, with no newline
+            if settingsPossible[settingSelected][valueIndex] == settings[settingSelected]: # If a value is the current value of the selected setting
+                print("   [current]") # Tell the user and add a newline
+
+            else:
+                print() # Add a newline
+
+        selection = input("Please make you selection: ") # Take the users input as to which value they want to assign to their selected setting
+
+        try: # Try to...
+            intSelection = int(selection) # Convert the users input from str to int
+            if intSelection in range(1, len(settingsPossible[settingSelected]) + 1): # If the users input corresponds to a listed value
+                valueSelected = settingsPossible[settingSelected][int(selection) - 1] # Store the selected value
+                writeJson("settings.json", {settingSelected: valueSelected}, dataDir) # Write it into our settings json file
+                print(f"Set \"{settingSelected}\" to \"{valueSelected}\"") # And tell the user we have done so
+            
+            else: # If the users input does not correspond to a listed value
+                print("Input out of range, exiting...") # Tell the user we are exiting
+                end(False) # And do so
+
+        except ValueError: # If the conversion to int fails
+            print("Exiting...") # Tell the user we are exiting
+            end(False) # And do so
 
     getSettings() # Refresh the settings in our settings dict with the newly changed setting
 
@@ -557,7 +689,7 @@ def editSettings(): # Shell for editing settings
         editSettings() # Restart the shell
 
     else:
-        end()
+        end(False)
 
 def editLayer(layer = "default.json"): # Shell for editing a layer file (default by default)
     LayerDict = readJson(layer, layerDir) # Get a dict of keybindings in the layer file
@@ -592,9 +724,9 @@ def editLayer(layer = "default.json"): # Shell for editing a layer file (default
         end() # And do so
 
     if bindingSelected == "leds":
-        print("LEDs detected on your keyboard:")
-        for led in device.capabilities(verbose=True)[("EV_LED", 17)]: # For all LEDs on the board
-            print(f"-{led[1]}: {led[0]}") # List it
+        print("standard LEDs:")
+        for led in standardLeds.items(): # For all LEDs on most boards
+            print(f"-{led[0]}: {led[1]}") # List it
 
         onLeds = input("Please choose what LEDs should be enable on this layer (comma and/or space separated list)") # Prompt the user for a list of LED numbers
         onLeds = onLeds.replace(",", " ").split() # Split the input list
@@ -603,7 +735,7 @@ def editLayer(layer = "default.json"): # Shell for editing a layer file (default
         for led in onLeds: # For all strs in the split list
             onLedsInt.append(int(led)) # Cast the str to int and add it to a list
 
-        writeJson(config()[1], {"leds": onLedsInt}) # Write the input list to the layer file
+        writeJson(layer, {"leds": onLedsInt}) # Write the input list to the layer file
 
     elif bindingSelected == "vars":
         varsDict = readJson(layer, layerDir)["vars"] # Get a dict of layer vars in the layer file
@@ -710,8 +842,8 @@ def editLayer(layer = "default.json"): # Shell for editing a layer file (default
 # Setup
 
 def firstUses(): # Setup to be run when a user first runs keebie
-    shutil.copytree(templateDataDir, dataDir) # Copy template configuration files to user
-    print(f"configuration files copied from {templateDataDir} to {dataDir}") # And inform the user
+    shutil.copytree(installDataDir + "data/", dataDir) # Copy template configuration files to user
+    print(f"configuration files copied from {installDataDir}/data/ to {dataDir}") # And inform the user
 
 
 
@@ -719,18 +851,22 @@ def firstUses(): # Setup to be run when a user first runs keebie
 
 parser = argparse.ArgumentParser() # Set up command line arguments
 
-parser.add_argument("--layers", help="Show saved layer files", action="store_true")
-parser.add_argument("--device", help="Change target device")
-parser.add_argument("--detect", help="Detect keyboard device file", action="store_true")
-parser.add_argument("--add", help="Add new keys", action="store_true")
-parser.add_argument("--settings", help="Edits settings file", action="store_true")
+parser.add_argument("--layers", "-l", help="Show saved layer files", action="store_true")
+parser.add_argument("--detect", "-d", help="Detect keyboard device file", action="store_true")
 
-try :
-    parser.add_argument("--edit", help="Edits specified layer file (or default layer if unspecified)", nargs="?", default=False, const="default.json", metavar="layer", choices=[i for i in os.listdir(layerDir) if os.path.splitext(i)[1] == ".json"])
+try:
+    parser.add_argument("--add", "-a", help="Adds new macros to the selected layer file (or default layer if unspecified)", nargs="?", default=False, const="default.json", metavar="layer", choices=[i for i in os.listdir(layerDir) if os.path.splitext(i)[1] == ".json"])
 except FileNotFoundError :
-    parser.add_argument("--edit", help="Edits specified layer file (or default layer if unspecified)", nargs="?", default=False, const="default.json", metavar="layer")
+    parser.add_argument("--add", "-a", help="Adds new macros to the selected layer file (or default layer if unspecified)", nargs="?", default=False, const="default.json", metavar="layer")
 
-parser.add_argument("--debug", help="Print extra debugging information", action="store_true")
+parser.add_argument("--settings", "-s", help="Edits settings file", action="store_true")
+
+try:
+    parser.add_argument("--edit", "-e", help="Edits specified layer file (or default layer if unspecified)", nargs="?", default=False, const="default.json", metavar="layer", choices=[i for i in os.listdir(layerDir) if os.path.splitext(i)[1] == ".json"])
+except FileNotFoundError :
+    parser.add_argument("--edit", "-e", help="Edits specified layer file (or default layer if unspecified)", nargs="?", default=False, const="default.json", metavar="layer")
+
+parser.add_argument("--verbose", "-v", help="Print extra debugging information", action="store_true")
 
 args = parser.parse_args()
 
@@ -741,37 +877,13 @@ print_debugs = args.debug
 
 print("Welcome to Keebie")
 
+signal.signal(signal.SIGINT, signal_handler)
+
 if not os.path.exists(dataDir): # If the user we are running as does not have user configuration files
     print("You are running keebie without user configuration files installed") # Inform the user
     firstUses() # Run first time user setup
 
-# Set up device
-if config()[0] == "/dev/input/by-id/put-your-device-name-here" and args.device == None:
-    print("You have not set your device file in " + dataDir + "config")
-    resp = input("Would you like to detect a device by keypress now? [Y/n] ")
-    if resp.lower().startswith("n"):
-        sys.exit(0)
-    else:
-        deviceString = detectKeyboard()
-        print(deviceString)
-        device = InputDevice(deviceString)
-        resp1 = input("Would you like to save this as your default device? [Y/n] ")
-        if resp1.lower().startswith("n") == False:
-            writeConfig(0, deviceString)
-elif args.device != None:
-    device = InputDevice("/dev/input/by-id/"+args.device)
-else:
-    device = InputDevice(config()[0]) # Get a reference to the keyboard on the first line of our config file
-
-
-# Set LEDs
-if "leds" in readJson(config()[1]):
-    setLeds(readJson(config()[1])["leds"])
-else:
-    print(f"Layer {readJson(config()[1])} has no leds property, writing empty")
-    writeJson(config()[1], {"leds": []})
-    setLeds([])
-
+setupMacroDevices() # Setup all devices
 
 getSettings() # Get settings from the json file in config
 
@@ -780,21 +892,8 @@ if args.layers: # If the user passed --layers
     getLayers() # Show the user all layer json files and their contents
 
 elif args.add: # If the user passed --add
-    device.grab() # Ensure only we receive input from the board
-    writeConfig(1, "default.json") # Ensure we are on the default layer
-    addKey() # Launch the key addition shell
-
-elif args.device: # If the user passed --device
-    device = InputDevice("/dev/input/by-id/"+args.device) # Get a reference to the specified keyboard
-    
-    if os.path.exists(layerDir+args.device+".json") == False: # If the keyboard doesn't yet have a layer json file
-        createLayer(args.device+".json") # Create one
-        print("Created layer file: " + layerDir + args.device + ".json") # And notify the user
-
-    writeConfig(1, args.device+".json") # Switch to the specified board's layer json file
-    print("Switched to layer file: " + args.device+".json") # Notify the user
-    device.grab() # Ensure only we receive input from the board
-    keebLoop() # Begin Reading the keyboard for macros
+    grabMacroDevices()
+    addKey(args.add) # Launch the key addition shell
 
 elif args.settings: # If the user passed --settings
     editSettings() # Launch the setting editing shell
@@ -803,11 +902,13 @@ elif args.detect: # If the user passed --detect
     detectKeyboard() # Launch the keyboard detection function
 
 elif args.edit: # If the user passed --edit
-    device.grab() # Ensure only we receive input from the board
+    grabMacroDevices()
     editLayer(args.edit) # Launch the layer editing shell
 
 else: # If the user passed nothing
     time.sleep(.5)
-    device.grab() # Ensure only we receive input from the board
-    writeConfig(1, "default.json") # Ensure we are on the default layer
-    keebLoop() # Begin Reading the keyboard for macros
+    grabMacroDevices() # Grab all the devices
+
+    while True : # Enter an infinite loop
+        readDevices() # Read all devices and process the keycodes
+        time.sleep(settings["loopDelay"]) # Sleep so we don't eat the poor little CPU

--- a/keebie.py
+++ b/keebie.py
@@ -870,7 +870,7 @@ parser.add_argument("--verbose", "-v", help="Print extra debugging information",
 
 args = parser.parse_args()
 
-print_debugs = args.debug
+print_debugs = args.verbose
 
 
 # Main code

--- a/keebie.py
+++ b/keebie.py
@@ -844,6 +844,11 @@ def newDevice(name = None, eventPath = "/dev/input"):
     """Add a new json file to devices/."""
     print("Setting up device")
 
+    initialLayer = input("Please provide a name for for this devices initial layer (non-existent layers will be created): ")
+
+    if os.path.exists(layerDir + initialLayer) == False:
+        createLayer(initialLayer)
+
     eventFile = detectKeyboard(eventPath) # Promt the user for a device
     eventFile = os.path.basename(eventFile) # Get the devices filename from its filepath
 
@@ -875,7 +880,7 @@ def newDevice(name = None, eventPath = "/dev/input"):
     selectedPropertiesList = [f"KERNEL==\"{eventFile}\""] # Make an udev rule matching the device file
 
     deviceJsonDict = { # Construct the device data dict
-        "initial_layer": "default.json",
+        "initial_layer": initialLayer,
         "event": eventFile,
         "udev_tests": selectedPropertiesList,
     }

--- a/keebie.py
+++ b/keebie.py
@@ -443,7 +443,7 @@ settingsPossible = { # A dict of lists of valid values for each setting (or if f
 }
 
 def getSettings(): # Reads the json file specified on the third line of config and sets the values of settings based on it's contents
-    print(f"Loading settings from {dataDir}/settings.json") # Notify the user we are getting settings and tell them the file we are using to do so
+    dprint(f"Loading settings from {dataDir}/settings.json") # Notify the user we are getting settings and tell them the file we are using to do so
 
     settingsFile = readJson("settings.json", dataDir) # Get a dict of the keys and values in our settings file
     for setting in settings.keys(): # For every setting we expect to be in our settings file
@@ -842,6 +842,8 @@ def editLayer(layer = "default.json"): # Shell for editing a layer file (default
 
 def newDevice(name = None, eventPath = "/dev/input"):
     """Add a new json file to devices/."""
+    print("Setting up device")
+
     eventFile = detectKeyboard(eventPath) # Promt the user for a device
     eventFile = os.path.basename(eventFile) # Get the devices filename from its filepath
 
@@ -851,7 +853,7 @@ def newDevice(name = None, eventPath = "/dev/input"):
     # for property in allUdevProperties.splitlines():
     #     udevProperties += [str(property).strip(), ]
 
-    input(f"\nDevice is {eventFile}, please press enter to continue...") # Ensure the stdin is empty
+    input("\nA udev rule will be made next, sudo may prompt you for a password. Press enter to continue...") # Ensure the stdin is empty
 
     # for propertyIndex in range(0, len(udevProperties)):
     #     print(f"-{propertyIndex + 1}: {udevProperties[propertyIndex]}")

--- a/layers/default.json
+++ b/layers/default.json
@@ -3,6 +3,7 @@
 	"vars": {
 		"greeting": "Hello World"
 	},
-	"KEY_SPACE": "echo '%greeting%!'"
+	"KEY_SPACE": "echo '%greeting%!'",
+	"KEY_ESC": "layer:default"
  }
  

--- a/makefile
+++ b/makefile
@@ -31,6 +31,7 @@ pkg: pre-pkg
 	./layers/=$(install_path)/data/layers \
 	./settings.json=$(install_path)/data/ \
 	./devices/=$(install_path)/data/devices \
+	./scripts/=$(install_path)/data/devices \
 	./setup_tools/=$(install_path)/setup_tools
 
 	# --before-install "./packaging/preinst" \

--- a/makefile
+++ b/makefile
@@ -7,6 +7,7 @@ pkg_type="tar"
 
 maintainer="Michael Basaj <michaelbasaj@protonmail.com>"
 version="1.0.0"
+iteration="0"
 # .SILENT:
 
 pre-pkg: check-for-changes
@@ -22,13 +23,15 @@ pkg: pre-pkg
 	-d python3 -d python3-evdev \
 	--maintainer $(maintainer) \
 	--version $(version) \
+	--iteration $(iteration) \
 	--license "none (yet)" \
 	--url https://github.com/robinuniverse/Keebie \
 	--description "A keyboard macro utility for Linux." \
 	./keebie.py=$(bin_path) \
-	./config=$(install_path) \
-	./layers/=$(install_path)/layers \
-	./settings.json=$(install_path)
+	./layers/=$(install_path)/data/layers \
+	./settings.json=$(install_path)/data/ \
+	./devices/=$(install_path)/data/devices \
+	./setup_tools/=$(install_path)/setup_tools
 
 	# --before-install "./packaging/preinst" \
 	# --after-install "./packaging/postinst" \

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ install_path="/usr/share/keebie/"
 pkg_type="tar"
 
 maintainer="Michael Basaj <michaelbasaj@protonmail.com>"
-version="1.0.0"
+version="1.1.0"
 iteration="0"
 # .SILENT:
 

--- a/makefile
+++ b/makefile
@@ -38,6 +38,7 @@ pkg: pre-pkg
 	# --before-install "./packaging/prerm" \
 	# --after-remove "./packaging/postem" \
 
+
 check-for-changes:
 	@echo "MODIFIED FILES"
 	@git status --porcelain | grep -E "^ ?M" || echo "None"
@@ -47,3 +48,16 @@ check-for-changes:
 
 	@echo "DELETED FILES"
 	@git status --porcelain | grep -E "^ ?D" || echo "None"
+
+
+install:
+	sudo cp -v ./keebie.py $(bin_path)
+
+	sudo mkdir -pv $(install_path)/data/ $(install_path)/setup_tools/
+
+	sudo cp -rv -t $(install_path)/data/ ./layers/ ./settings.json ./devices/
+	sudo cp -rv -t $(install_path)/setup_tools/ ./setup_tools/
+
+
+remove:
+	sudo rm -rfv $(bin_path) $(install_path)

--- a/makefile
+++ b/makefile
@@ -58,7 +58,7 @@ install:
 	sudo mkdir -pv $(install_path)/data/ $(install_path)/setup_tools/
 
 	sudo cp -rv -t $(install_path)/data/ ./layers/ ./settings.json ./devices/ ./scripts/
-	sudo cp -rv -t $(install_path)/setup_tools/ ./setup_tools/
+	sudo cp -rv -t $(install_path)/ ./setup_tools/
 
 
 remove:

--- a/makefile
+++ b/makefile
@@ -27,11 +27,12 @@ pkg: pre-pkg
 	--license "none (yet)" \
 	--url https://github.com/robinuniverse/Keebie \
 	--description "A keyboard macro utility for Linux." \
+	--exclude "*.keep" \
 	./keebie.py=$(bin_path) \
 	./layers/=$(install_path)/data/layers \
 	./settings.json=$(install_path)/data/ \
 	./devices/=$(install_path)/data/devices \
-	./scripts/=$(install_path)/data/devices \
+	./scripts/=$(install_path)/data/scripts \
 	./setup_tools/=$(install_path)/setup_tools
 
 	# --before-install "./packaging/preinst" \
@@ -56,7 +57,7 @@ install:
 
 	sudo mkdir -pv $(install_path)/data/ $(install_path)/setup_tools/
 
-	sudo cp -rv -t $(install_path)/data/ ./layers/ ./settings.json ./devices/
+	sudo cp -rv -t $(install_path)/data/ ./layers/ ./settings.json ./devices/ ./scripts/
 	sudo cp -rv -t $(install_path)/setup_tools/ ./setup_tools/
 
 

--- a/readme.md
+++ b/readme.md
@@ -6,74 +6,68 @@ More keyboards = faster hacking
 
 #### What does it do:
 
-Keebie is basically a small script for assigning and executing commands on a second (or third, fourth, etc., the only limit should be how many ports you have) keyboard. So you can make the spacebar search for a window and paste something. Or make the M button run a script.
+Keebie is basically a small script for assigning and executing commands on a theoretically unlimited number of keyboards. So you can make the spacebar search for a window and paste something. Or make the M button run a script.
 
 
 
 #### How to set up:
 
-Okay so this point is still a little bit uh, well. Experimental. I am not very experienced with permissions systems in Linux and this involves that so if you know a better way of doing what I'm doing, please tell me. Anyways, with that out of the way, let's go over what you need to do to set this up.
+ - If somebody has made available a package for your OS go ahead install it and move on.
 
-- **Find the input file of your target keyboard**
-  - You can do this by running `ls /dev/input/by-id/`, and looking for a name that looks like it matches. Test to see if you've found it by running `cat /dev/input/by-id/[the-device-you-think-it-is]`( this will most likely have event and/or kbd in the name ) There will likely be more than one. keep trying that command and pressing buttons on your target keyboard. once your console starts to output garbage when you press buttons on the target keyboard, you've found it. note that down.
-  - If nothing in `/dev/input/by-id/` looks like the keyboard you want (as may happen if, for example, you have a PS/2 keyboard) then try looking in `/dev/input/by-path/` or `/dev/input/` following the same procedure as above, this will require much more trial and error but is functionally the same as using `/dev/input/by-id` as `/dev/input/by-id` and `/dev/input/by-path` are populated by links to files in `/dev/input/`.
-- **Give yourself permission to access that device.**
-  - This is that part I wasn't sure about. I suspect that the way I did it was wrong, but I'll give you the way I did it, and the way that seems like the right way but didn't work for me.
-  - What I ended up doing was `sudo chmod a+rw /dev/input/by-id/[my-device-name]`.
-  - What is typically done: most inputs should belong to a group ( usually `input`, but check by using `ls -l /dev/input/by-id/[my-device-name]` ), and you should be able to add yourself to whatever group the device belongs to by doing something like `usermod -a -G input yourusername`. In my case the device didn't seem to belong to any group except for root. In other cases even when the file belongs to input and the user is added to input error have still resulted.
-- **Add your device file directory to the first line of the config file**
+ - If not you can download the source and run `make install`. Make sure you have `python3` and `python3-evdev` (or your package manager's equivalents) installed.
 
-And that should have you up and ready to roll. If when you run the script, you get an error saying something about permission denied, something has gone wrong with step 2. Good luck lmao (try running the `chmod` command if you didn't before).
+ - If you would like to build a package of Keebie [install fpm](https://fpm.readthedocs.io/en/latest/installing.html) run `make pkg pkg_type="<type>"`.
 
-
-
-#### Usage:
-
-Just dump the files anywhere and run `keebie.py` and if everything it up and running, you should be good to go. Test your second keyboard by pressing spacebar which is bound to a test message by default. To run with more keyboards, run the script again with the `--device <dev-id>` option for however many devices you want to add. 
+ Once you've installed Keebie you should run `keebie --new` to set up a macro device.
 
 
 
 #### Options:
 
-`--device <device-id>` Launches the script attatched to specified device, creating a new layer file specifically for it if it doesn't already exist. Press ESC to return to default layer.
+`--layers`, `-l` 
+  Display the contents of all layer files.
 
-`--add`: Launches into the script addition shell to add a command to the default layer. Instructions should be pretty straightforward. Any commands entered will be launched when the key(s) you enter are pressed, and if you try to bind the same key twice your new value will overwrite the old one. There is some special syntax that can be used in this entry that will allow for special functions:
+`--detect`, `-d`
+  Tell you the path to a device you press a key on.
 
-- `layer:<layername>`: Will create a layer file in  `/layers/`, and let you bind switching to it to any key
-  - ( this will create a layer with a default layout of only having `ESC` return you to the default layer, you can add to it by launching the script, switching to it, then running `python keebie.py -a` again )
-- `script:<scriptname.sh (options)>`: Will launch a `< scriptname.sh (options) >` from `/scripts/`
-  - ( same as `bash ~/whereveryourfolderis/scripts/scriptname.sh (options)` )
-- `py:<pythonscript.py (options)>`: Will launch `< pythonscript.py (options) >` from `/scripts/` 
-  - ( same as `python ~/whereveryourfolderis/scripts/pythonscript.py (options)` )
-- `py2:<pythonscript.py (options)>`: Will launch `< python2script.py (options) >` from `/scripts/` 
-  - ( same as `python2 ~/whereveryourfolderis/scripts/pythonscript.py (options)` )
-- `py3:<pythonscript.py (options)>`: Will launch `< python3script.py (options) >` from `/scripts/` 
-  - ( same as `python3 ~/whereveryourfolderis/scripts/pythonscript.py (options)` )
-- `exec:<executablefile (options)>`: Will launch `< executablefile (options) >` from `/scripts/` 
-  - ( same as `~/whereveryourfolderis/scripts/executablefile (options)` )
+`--add [layer]`, `-a [layer]`
+  Launch a shell to add a macro to a layer, if no layer is specified this adds to `default.json`.
+  This requires that at least one device has been set up with `--edit`
 
-`--layers`: Lists all layer files and all of their contents.
+`--settings`, `-s`
+  Launch a shell to edit your settings, see the settings section below
 
-`--edit`: Launches into a shell to delete or edit key bindings.
+`--edit [layer]`, `-e [layer]`
+  Launch a shell to edit a layer and its macros, if no layer is specified this adds to `default.json`.
 
-`--settings`: Launches into the settings editing shell to change your settings. The setting you can change, and their values, are:
+`--new`, `-n`
+  Launch a shell to set up a device for use with Keebie, also make a udev rule to give access to the device which will require you to give a password to sudo.
+  You should run this should first upon installation.
 
-- `multiKeyMode`: How multiple held keys are handled. Please note that bindings created with either setting won't always work (or work the same) when using the other setting.
-  - `combination`: Multiple held keys are treated the same regardless of the order the were pressed in. This is the default and is in line with how most other programs work.
-  - `sequence`: The order in which key were pressed (and held!) is considered and allows for distinct bindings on the same set of keys based on the order they were pressed.
-- `forceBackground`: Whether commands should be forced to run in the background.
-  - `True`: Forces commands to run in the background by appending an `&` to the command if one is not present.
-  - `False`: Does not affect commands. This is the default.
-- `backgroundInversion`: Whether to invert background commands to non-background commands and vice-versa. This setting is processed after `forceBackground`, this means that if both are set to `True` all commands will be forced not to run in the background.
-  - `True`: Inverts whether a command runs in the background by removing `&`s from the end of a command or, if no `&` is pressent, appending an `&` to the command.
-  - `False`: Does not affect commands. This is the default.
+`--verbose`, `-v`
+  Makes Keebie more verbose, good for debugging.
 
-`-h` or `--help`: Shows a short help message.
+`-h`, `--help`
+  Print usage information.
 
 
 
-#### Some tips:
+#### Settings:
 
-**Multi-script drifting**
+Keebie has a few settings that may be edited with `--settings` (or `-s`), here is what the settings are.
 
-​Put an `&` at the end of your commands. This will effectively make any commands you run through it into their own process and keep from any long winded scripts or error messages keeping the rest of your macros from responding. You can also use the `forceBackground` setting to force all commands to run in the their own process, or use the `backgroundInversion` setting to make all commands run in their own process *unless* an `&` in at the end of the command (this is more convenient if you want seprate processes by default).
+`multiKeyMode`
+  Decides how Keebie handles multiple held keys.
+  `combination`: How you would expect things to work, held keys are treated together.
+  `sequence`: Held keys are treated together based on the order they were held in. Its weird but might help to cram more macros onto a keyboard.
+
+`forceBackground`
+  `True`: All commands should be run in the background (as opposed to waiting for them to finish before continuing).
+  `False`: Commands are left unchanged (for now).
+
+`backgroundInversion`
+  `True`: Make all background commands are made to run in the foreground an vice-versa. If combined with `forceBackground` is `True` all commands run in the foreground.
+  `False`: Commands are left unchanged.
+
+`loopDelay`
+  Decides how often Keebie reads devices. Higher values lead to less responsive macros, lower values lead to higher CPU usage, setting this to 0 will eat a lot of CPU time.

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,9 @@ Keebie is basically a small script for assigning and executing commands on a the
    - Launch a shell to set up a device for use with Keebie, also make a udev rule to give access to the device which will require you to give a password to sudo.
    - You should run this should first upon installation.
 
+ - `--remove [device]`, `-r [device]`
+   - Launch into a shell to remove device file and udev rule, if you don't specify a device you will be prompted for one.
+
  - `--verbose`, `-v`
    - Makes Keebie more verbose, good for debugging.
 

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Keebie is basically a small script for assigning and executing commands on a the
 
  - If not you can download the source and run `make install`. Make sure you have `python3` and `python3-evdev` (or your package manager's equivalents) installed.
 
- - If you would like to build a package of Keebie [install fpm](https://fpm.readthedocs.io/en/latest/installing.html) and run `make pkg pkg_type="<type>"`.
+ - If you would like to build a package of Keebie download the source, [install fpm](https://fpm.readthedocs.io/en/latest/installing.html), and run `make pkg pkg_type="<type>"`.
 
  Once you've installed Keebie you should run `keebie --new` to set up a macro device.
 

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ Keebie is basically a small script for assigning and executing commands on a the
 `--add [layer]`, `-a [layer]`
   Launch a shell to add a macro to a layer, if no layer is specified this adds to `default.json`.
   This requires that at least one device has been set up with `--edit`
+  See layer syntax section below for more information on special syntax for doing things other than commands.
 
 `--settings`, `-s`
   Launch a shell to edit your settings, see the settings section below
@@ -71,3 +72,21 @@ Keebie has a few settings that may be edited with `--settings` (or `-s`), here i
 
 `loopDelay`
   Decides how often Keebie reads devices. Higher values lead to less responsive macros, lower values lead to higher CPU usage, setting this to 0 will eat a lot of CPU time.
+
+
+
+#### Layer syntax:
+
+Keebie interprets some special syntax listed below
+
+`layer:<layername>`
+  This will switch to the specified layer, when entering this into the `--add` shell you will be prompted to set up the layer.
+
+`<script type>:<script name>`
+  This will launch different types of scripts in `~/.config/keebie/scripts/`.
+  Script types are as follows
+   - `script` will launch the named script with `bash`.
+   - `py` will launch the named script with `python`.
+   - `py2` will launch the named script with `python2`.
+   - `py3` will launch the named script with `python3`.
+   - `exec` will execute the named file without an interpreter.

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Keebie is basically a small script for assigning and executing commands on a the
 
  - If not you can download the source and run `make install`. Make sure you have `python3` and `python3-evdev` (or your package manager's equivalents) installed.
 
- - If you would like to build a package of Keebie [install fpm](https://fpm.readthedocs.io/en/latest/installing.html) run `make pkg pkg_type="<type>"`.
+ - If you would like to build a package of Keebie [install fpm](https://fpm.readthedocs.io/en/latest/installing.html) and run `make pkg pkg_type="<type>"`.
 
  Once you've installed Keebie you should run `keebie --new` to set up a macro device.
 
@@ -24,31 +24,31 @@ Keebie is basically a small script for assigning and executing commands on a the
 
 #### Options:
 
-`--layers`, `-l` 
+`--layers`, `-l`  
   Display the contents of all layer files.
 
-`--detect`, `-d`
+`--detect`, `-d`  
   Tell you the path to a device you press a key on.
 
-`--add [layer]`, `-a [layer]`
-  Launch a shell to add a macro to a layer, if no layer is specified this adds to `default.json`.
-  This requires that at least one device has been set up with `--edit`
+`--add [layer]`, `-a [layer]`  
+  Launch a shell to add a macro to a layer, if no layer is specified this adds to `default.json`.  
+  This requires that at least one device has been set up with `--edit`  
   See layer syntax section below for more information on special syntax for doing things other than commands.
 
-`--settings`, `-s`
+`--settings`, `-s`  
   Launch a shell to edit your settings, see the settings section below
 
-`--edit [layer]`, `-e [layer]`
+`--edit [layer]`, `-e [layer]`  
   Launch a shell to edit a layer and its macros, if no layer is specified this adds to `default.json`.
 
-`--new`, `-n`
-  Launch a shell to set up a device for use with Keebie, also make a udev rule to give access to the device which will require you to give a password to sudo.
+`--new`, `-n`  
+  Launch a shell to set up a device for use with Keebie, also make a udev rule to give access to the device which will require you to give a password to sudo.  
   You should run this should first upon installation.
 
-`--verbose`, `-v`
+`--verbose`, `-v`  
   Makes Keebie more verbose, good for debugging.
 
-`-h`, `--help`
+`-h`, `--help`  
   Print usage information.
 
 
@@ -57,20 +57,20 @@ Keebie is basically a small script for assigning and executing commands on a the
 
 Keebie has a few settings that may be edited with `--settings` (or `-s`), here is what the settings are.
 
-`multiKeyMode`
-  Decides how Keebie handles multiple held keys.
-  `combination`: How you would expect things to work, held keys are treated together.
-  `sequence`: Held keys are treated together based on the order they were held in. Its weird but might help to cram more macros onto a keyboard.
+`multiKeyMode`  
+  Decides how Keebie handles multiple held keys.  
+  `combination`: How you would expect things to work, held keys are treated together.  
+  `sequence`: Held keys are treated together based on the order they were held in. Its weird but might help to cram more macros onto a keyboard.  
 
-`forceBackground`
-  `True`: All commands should be run in the background (as opposed to waiting for them to finish before continuing).
-  `False`: Commands are left unchanged (for now).
+`forceBackground`  
+  `True`: All commands should be run in the background (as opposed to waiting for them to finish before continuing).  
+  `False`: Commands are left unchanged (for now).  
 
-`backgroundInversion`
-  `True`: Make all background commands are made to run in the foreground an vice-versa. If combined with `forceBackground` is `True` all commands run in the foreground.
-  `False`: Commands are left unchanged.
+`backgroundInversion`  
+  `True`: Make all background commands are made to run in the foreground an vice-versa. If combined with `forceBackground` is `True` all commands run in the foreground.  
+  `False`: Commands are left unchanged.  
 
-`loopDelay`
+`loopDelay`  
   Decides how often Keebie reads devices. Higher values lead to less responsive macros, lower values lead to higher CPU usage, setting this to 0 will eat a lot of CPU time.
 
 
@@ -79,14 +79,14 @@ Keebie has a few settings that may be edited with `--settings` (or `-s`), here i
 
 Keebie interprets some special syntax listed below
 
-`layer:<layername>`
+`layer:<layername>`  
   This will switch to the specified layer, when entering this into the `--add` shell you will be prompted to set up the layer.
 
-`<script type>:<script name>`
-  This will launch different types of scripts in `~/.config/keebie/scripts/`.
-  Script types are as follows
-   - `script` will launch the named script with `bash`.
-   - `py` will launch the named script with `python`.
-   - `py2` will launch the named script with `python2`.
-   - `py3` will launch the named script with `python3`.
-   - `exec` will execute the named file without an interpreter.
+`<script type>:<script name>`  
+  This will launch different types of scripts in `~/.config/keebie/scripts/`.  
+  Script types are as follows  
+   - `script` will launch the named script with `bash`.  
+   - `py` will launch the named script with `python`.  
+   - `py2` will launch the named script with `python2`.  
+   - `py3` will launch the named script with `python3`.  
+   - `exec` will execute the named file without an interpreter.  

--- a/readme.md
+++ b/readme.md
@@ -24,32 +24,32 @@ Keebie is basically a small script for assigning and executing commands on a the
 
 #### Options:
 
-`--layers`, `-l`  
-  Display the contents of all layer files.
+ - `--layers`, `-l`
+   - Display the contents of all layer files.
 
-`--detect`, `-d`  
-  Tell you the path to a device you press a key on.
+ - `--detect`, `-d`
+   - Tell you the path to a device you press a key on.
 
-`--add [layer]`, `-a [layer]`  
-  Launch a shell to add a macro to a layer, if no layer is specified this adds to `default.json`.  
-  This requires that at least one device has been set up with `--edit`  
-  See layer syntax section below for more information on special syntax for doing things other than commands.
+ - `--add [layer]`, `-a [layer]`
+   - Launch a shell to add a macro to a layer, if no layer is specified this adds to `default.json`.
+   - This requires that at least one device has been set up with `--edit`
+   - See layer syntax section below for more information on special syntax for doing things other than commands.
 
-`--settings`, `-s`  
-  Launch a shell to edit your settings, see the settings section below
+ - `--settings`, `-s`
+   - Launch a shell to edit your settings, see the settings section below
 
-`--edit [layer]`, `-e [layer]`  
-  Launch a shell to edit a layer and its macros, if no layer is specified this adds to `default.json`.
+ - `--edit [layer]`, `-e [layer]`
+   - Launch a shell to edit a layer and its macros, if no layer is specified this adds to `default.json`.
 
-`--new`, `-n`  
-  Launch a shell to set up a device for use with Keebie, also make a udev rule to give access to the device which will require you to give a password to sudo.  
-  You should run this should first upon installation.
+ - `--new`, `-n`
+   - Launch a shell to set up a device for use with Keebie, also make a udev rule to give access to the device which will require you to give a password to sudo.
+   - You should run this should first upon installation.
 
-`--verbose`, `-v`  
-  Makes Keebie more verbose, good for debugging.
+ - `--verbose`, `-v`
+   - Makes Keebie more verbose, good for debugging.
 
-`-h`, `--help`  
-  Print usage information.
+ - `-h`, `--help`
+   - Print usage information.
 
 
 
@@ -57,21 +57,21 @@ Keebie is basically a small script for assigning and executing commands on a the
 
 Keebie has a few settings that may be edited with `--settings` (or `-s`), here is what the settings are.
 
-`multiKeyMode`  
-  Decides how Keebie handles multiple held keys.  
-  `combination`: How you would expect things to work, held keys are treated together.  
-  `sequence`: Held keys are treated together based on the order they were held in. Its weird but might help to cram more macros onto a keyboard.  
+ - `multiKeyMode`
+   - Decides how Keebie handles multiple held keys.
+     - `combination`: How you would expect things to work, held keys are treated together.
+     - `sequence`: Held keys are treated together based on the order they were held in. Its weird but might help to cram more macros onto a keyboard.
 
-`forceBackground`  
-  `True`: All commands should be run in the background (as opposed to waiting for them to finish before continuing).  
-  `False`: Commands are left unchanged (for now).  
+ - `forceBackground`
+   - `True`: All commands should be run in the background (as opposed to waiting for them to finish before continuing).
+   - `False`: Commands are left unchanged (for now).
 
-`backgroundInversion`  
-  `True`: Make all background commands are made to run in the foreground an vice-versa. If combined with `forceBackground` is `True` all commands run in the foreground.  
-  `False`: Commands are left unchanged.  
+ - `backgroundInversion`
+   - `True`: Make all background commands are made to run in the foreground an vice-versa. If combined with `forceBackground` is `True` all commands run in the foreground.
+   - `False`: Commands are left unchanged.
 
-`loopDelay`  
-  Decides how often Keebie reads devices. Higher values lead to less responsive macros, lower values lead to higher CPU usage, setting this to 0 will eat a lot of CPU time.
+ - `loopDelay`
+   - Decides how often Keebie reads devices. Higher values lead to less responsive macros, lower values lead to higher CPU usage, setting this to 0 will eat a lot of CPU time.
 
 
 
@@ -79,14 +79,14 @@ Keebie has a few settings that may be edited with `--settings` (or `-s`), here i
 
 Keebie interprets some special syntax listed below
 
-`layer:<layername>`  
-  This will switch to the specified layer, when entering this into the `--add` shell you will be prompted to set up the layer.
+ - `layer:<layername>`
+   - This will switch to the specified layer, when entering this into the `--add` shell you will be prompted to set up the layer.
 
-`<script type>:<script name>`  
-  This will launch different types of scripts in `~/.config/keebie/scripts/`.  
-  Script types are as follows  
-   - `script` will launch the named script with `bash`.  
-   - `py` will launch the named script with `python`.  
-   - `py2` will launch the named script with `python2`.  
-   - `py3` will launch the named script with `python3`.  
-   - `exec` will execute the named file without an interpreter.  
+ - `<script type>:<script name>`
+   - This will launch different types of scripts in `~/.config/keebie/scripts/`.
+   - Script types are as follows.
+      - `script` will launch the named script with `bash`.
+      - `py` will launch the named script with `python`.
+      - `py2` will launch the named script with `python2`.
+      - `py3` will launch the named script with `python3`.
+      - `exec` will execute the named file without an interpreter.

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,6 @@
 {
 	"multiKeyMode": "combination",
 	"forceBackground": false,
-	"backgroundInversion": false
+	"backgroundInversion": false,
+	"loopDelay": 0.1
 }

--- a/setup_tools/udevRule.sh
+++ b/setup_tools/udevRule.sh
@@ -5,10 +5,10 @@
 # find the values vendor-id and product-id by using lsusb command
 # Note make sure you copy keebie.service to /etc/systemd/system before executing this script as sudo
 
-touch /etc/udev/rules.d/85-redragon-keyboard.rules 
+touch /etc/udev/rules.d/"$2".rules 
 cd /etc/udev/rules.d/
 
-echo 'SUBSYSTEM=="input", ATTRS{idVendor}=="0c45", ATTRS{idProduct}=="5004", MODE="0664", ENV{SYSTEMD_WANTS}="keebie.service"  TAG+="systemd"' > 85-redragon-keyboard.rules 
+echo 'SUBSYSTEM=="input", '"$1"'MODE="0664", ENV{SYSTEMD_WANTS}="keebie.service"  TAG+="systemd"' > "$2".rules 
 
 sleep 1s
 

--- a/setup_tools/udevRule.sh
+++ b/setup_tools/udevRule.sh
@@ -5,10 +5,10 @@
 # find the values vendor-id and product-id by using lsusb command
 # Note make sure you copy keebie.service to /etc/systemd/system before executing this script as sudo
 
-touch /etc/udev/rules.d/"$2".rules 
+touch /etc/udev/rules.d/"$2"
 cd /etc/udev/rules.d/
 
-echo 'SUBSYSTEM=="input", '"$1"'MODE="0664", ENV{SYSTEMD_WANTS}="keebie.service"  TAG+="systemd"' > "$2".rules 
+echo 'SUBSYSTEM=="input", '"$1"'MODE="0666", ENV{SYSTEMD_WANTS}="keebie.service"  TAG+="systemd"' > "$2"
 
 sleep 1s
 


### PR DESCRIPTION
 - Adds support for reading from multiple devices simultaneously.
   - Each device can switch layers independently.
   - Info about devices is stored in json files in`device/`.
   - Devices can be added with `--add` and removed with `--remove`.
   - `--add` automatically makes udev rules using the devices KERNEL property (I believe this is unique per device); `--remove` removes these.

 - Plus some other things.
   - Overhauls `readme.md` (about time).
   - Adds `install` and `remove` make targets.
   - Changes `setup_tools/udevRule.sh` to give `0666` (Because without write permissions layer LEDs don't work).
   - Adds a bunch of `sudo`ing where I didn't know it was needed before (because I was in the `input` group).

 - Some downsides.
   - `keebie.py` now polls devices (by default ten times a second) instead of waiting for events; this will increase CPU usage, the impact may be influenced with the new `loopDeley` setting.
   - Incompatible with all other version (which use `config`).