### PR TITLE
Multi process device sharing

### DIFF
--- a/keebie.py
+++ b/keebie.py
@@ -33,23 +33,33 @@ layerDir = dataDir + "layers/" # Cache the full path to the /layers directory
 deviceDir = dataDir + "devices/" # Cache the full path to the /devices directory
 scriptDir = dataDir + "scripts/" # Cache the full path to the /scripts directory
 
+pidPath = "/var/run/keebie/keebie.pid" # A Path into which we should store the PID of a running looping instance of keebie
+
 
 
 # Signal handling
 
 devicesAreGrabbed = False # A bool to track if devices have beed grabbed
 
+savedPid = False # A bool to store if this process has writen to the PID file
+paused = False # A bool to store if the process has sent a pause signal to a running keebie loop
+havePaused = False # A bool to store if this process has been signaled to pause by wnother instance
+
 def signal_handler(signal, frame):
     end()
 
-def end(ungrab=None): # Properly close the device file and exit the script
+def end(): # Properly close the device file and exit the script
     print() # Make sure there is a newline
-    if ungrab == None: # If ungrab was not set
-        ungrab = devicesAreGrabbed # set it to devicesAreGrabbed
 
-    if ungrab == True: # If we need to clean up grabbed macroDevices
+    if devicesAreGrabbed == True: # If we need to clean up grabbed macroDevices
         ungrabMacroDevices() # Ungrab all devices
         closeDevices() # Cleanly close all devices
+
+    if havePaused == True: # if we have told a running keebie loop to pause
+        sendResume() # Tell it to resume
+
+    if savedPid == True: # If we have writen to the PID file
+        removePid() # Remove our PID files
 
     sys.exit(0) # Exit without error
 
@@ -226,11 +236,8 @@ class macroDevice():
     def close(self):
         """Try to close the device file gracefully."""
         print("closing device " + self.name)
-        if self.device.fd > -1:
-            try:
-                os.close(self.device.fd)
-            finally:
-                self.device.fd = -1
+
+        self.device.close() # Close the device
 
     def read(self, process=True):
         """Read all queued events (if any), update the ledger, and process the keycodes (or don't)."""
@@ -361,7 +368,7 @@ def grabMacroDevices():
 
 def ungrabMacroDevices():
     """Ungrab all devices with macroDevices."""
-    global devicesAreGrabbed # Globallize devicesAreGrabbed
+    global devicesAreGrabbed # Globalize devicesAreGrabbed
     devicesAreGrabbed = False # And set it false
 
     for device in macroDeviceList:
@@ -942,6 +949,120 @@ def firstUses(): # Setup to be run when a user first runs keebie
 
 
 
+# Inter-process communication
+
+def savePid():
+    """Save our PID into the PID file. Raise FileExistsError if the PID file already exists."""
+    dprint("Saving PID to " + pidPath)
+
+    global savedPid # Globalize savedPid
+
+    pid = os.getpid() # Get this process' PID
+
+    if os.path.exists(pidPath) == False: # If no PID file already exists
+        with open(pidPath, "wt") as pidFile: # Create and open the PID file
+            pidFile.write(str(pid)) # Write our PID into it
+            savedPid = True # Record that we have saved our PID
+
+    else:
+        dprint("PID already recorded")
+        raise FileExistsError("PID already recorded")
+
+def removePid():
+    """Remove the PID file if it exists."""
+    dprint("Removing PID file " + pidPath)
+
+    global savedPid # Globalize savedPid
+
+    if os.path.exists(pidPath) == True: # If the PID file exists
+        os.remove(pidPath) # Remove it
+        savedPid = False # And record it's removal
+
+    else:
+        print("PID was never stored?")
+
+def getPid():
+    """Return the PID in the PID file. Raise FileNotFoundError if the file does not exist."""
+    if os.path.exists(pidPath) == True: # If the PID file exists
+        with open(pidPath, "rt") as pidFile: # Open it
+            return int(pidFile.read()) # And return it's contents as an int
+
+    else:
+        dprint("PID file dosn't exist")
+        raise FileNotFoundError("PID file dosn't exist")
+
+def checkPid():
+    """Try to get the PID and check if it is valid. Raise FileNotFoundError if the PID file does not exist. Raise ProcessLookupError and remove the PID file if no process has the PID."""
+    pid = getPid() # Try to get the PID in the PID file, this will raise en exception if the file is missing
+
+    try:
+        os.kill(pid, 0) # Send signal 0 to the process, this will raise OSError if the process doesn't exist
+    
+    except OSError:
+        dprint("PID invalid")
+        removePid() # Remove the PID file since its wrong
+        raise ProcessLookupError("PID invalid")
+
+def sendPause(waitSafeTime=None):
+    """If a valid PID is found in the PID file send SIGUSR1 to the process."""
+    try:
+        dprint("Sending pause")
+
+        checkPid() # Check if the PID file point's to a valid process
+
+        global havePaused
+        havePaused = True # Save that we have paused the process
+        
+        os.kill(getPid(), signal.SIGUSR1) # Pause the process
+
+        if waitSafeTime == None:
+            waitSafeTime = settings["loopDelay"] * 3 # Set how long we should wait
+
+        time.sleep(waitSafeTime) # Wait a bit to make sure the process paused itself
+
+    except (FileNotFoundError, ProcessLookupError): # If the PID file doesn't exist or the process isn't valid
+        dprint("No process to pause")
+
+
+def sendResume():
+    """If a valid PID is found in the PID file send SIGUSR2 to the process."""
+    try:
+        dprint("Sending resume")
+        
+        checkPid() # Check if the PID file point's to a valid process
+
+        global havePaused
+        havePaused = False # Save that we have resumed the process
+
+        os.kill(getPid(), signal.SIGUSR2) # Resume the process
+
+    except (FileNotFoundError, ProcessLookupError): # If the PID file doesn't exist or the process isn't 
+        dprint("No process to resume")
+
+def pause(signal, frame):
+    """Ungrab all macro devices and wait until paused is set to fales by another function (resume())."""
+    print("Pausing...")
+
+    global paused
+    paused = True # Save that we have been paused
+
+    ungrabMacroDevices() # Ungrab all devices so the pausing process can use them
+
+def resume(signal, frame):
+    """Grab all macro devices and refresh our setting after being paused (or just if some changes were made we need to load)."""
+    print("Resuming...")
+
+    global paused
+    
+    getSettings() # Refresh our settings
+
+    if paused == True: # If we were paused prior
+        grabMacroDevices() # Grab all our devices back
+
+    paused = False # Save that we are no longer paused
+
+
+
 # Arguments
 
 parser = argparse.ArgumentParser() # Set up command line arguments
@@ -994,16 +1115,22 @@ if args.layers: # If the user passed --layers
     getLayers() # Show the user all layer json files and their contents
 
 elif args.add: # If the user passed --add
+    sendPause() # Ask a running keebie loop (if one exists) to pause so we can use the devices
+
     grabMacroDevices()
     addKey(args.add) # Launch the key addition shell
 
 elif args.settings: # If the user passed --settings
+    sendPause() # Ask a running keebie loop (if one exists) to pause so it will reload its settings when we're done
+
     editSettings() # Launch the setting editing shell
 
 elif args.detect: # If the user passed --detect
     print(detectKeyboard("/dev/input/")) # Launch the keyboard detection function
 
 elif args.edit: # If the user passed --edit
+    sendPause() # Ask a running keebie loop (if one exists) to pause so we can use the devices
+
     grabMacroDevices()
     editLayer(args.edit) # Launch the layer editing shell
 
@@ -1014,6 +1141,21 @@ elif args.remove: # If the user passed --remove
     removeDevice(args.remove) # Launch the device removal shell
 
 else: # If the user passed nothing
+    try:
+        savePid() # Try to save our PID to the PID file
+
+    except FileExistsError: # If the PID file already exists
+        try:
+            checkPid() # Check if it is valid, this will raise an error if it isn't
+            print("Another instance of keebie is already processing macros, exiting...") 
+            end()
+
+        except ProcessLookupError: # If the PID file pointed to an invalid PID
+            savePid() # Save our PID to the PID file (which checkPid() will have removed)
+
+    signal.signal(signal.SIGUSR1, pause) # Bind SIGUSR1 to pause()
+    signal.signal(signal.SIGUSR2, resume) # Bind SIGUSR2 to remove()
+
     time.sleep(.5)
     grabMacroDevices() # Grab all the devices
 

--- a/makefile
+++ b/makefile
@@ -28,6 +28,8 @@ pkg: pre-pkg
 	--url https://github.com/robinuniverse/Keebie \
 	--description "A keyboard macro utility for Linux." \
 	--exclude "*.keep" \
+	--after-install "./packaging/postinst" \
+	--after-remove "./packaging/postrm" \
 	./keebie.py=$(bin_path) \
 	./layers/=$(install_path)/data/layers \
 	./settings.json=$(install_path)/data/ \
@@ -36,9 +38,7 @@ pkg: pre-pkg
 	./setup_tools/=$(install_path)/setup_tools
 
 	# --before-install "./packaging/preinst" \
-	# --after-install "./packaging/postinst" \
 	# --before-install "./packaging/prerm" \
-	# --after-remove "./packaging/postem" \
 
 
 check-for-changes:
@@ -53,6 +53,8 @@ check-for-changes:
 
 
 install:
+	# sudo ./packaging/preinst
+
 	sudo cp -v ./keebie.py $(bin_path)
 
 	sudo mkdir -pv $(install_path)/data/ $(install_path)/setup_tools/
@@ -60,6 +62,10 @@ install:
 	sudo cp -rv -t $(install_path)/data/ ./layers/ ./settings.json ./devices/ ./scripts/
 	sudo cp -rv -t $(install_path)/ ./setup_tools/
 
+	sudo ./packaging/postinst
+
 
 remove:
+	# sudo ./packaging/prerm
 	sudo rm -rfv $(bin_path) $(install_path)
+	# sudo ./packaging/postrm

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo mkdir -pv "/var/run/keebie/"
+
+sudo chmod -v 777 "/var/run/keebie/"

--- a/packaging/postrm
+++ b/packaging/postrm
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo rm -rfv "/var/run/keebie/"


### PR DESCRIPTION
Changes `keebie.py` to write its PID into a file when starting normally, when another instance of Keebie needs to grab the devices (for adding a macro etc.) it sends the signal `SIGUSR1` to the main Keebie process which then ungrabs and closes its devices for the second instance to use. When the second instance is done it sends `SIGUSR2` the the main process which then grabs the devices back.

In short this lets Keebie instances started with `--add`, `--settings`, `--edit`, `--new`, or `--remove` work without having to stop a running process.