### PR TITLE
Use udev symlinks instead of event file paths

### DIFF
--- a/keebie.py
+++ b/keebie.py
@@ -989,7 +989,7 @@ def newDevice(eventPath = "/dev/input/"):
 
     dev = InputDevice(eventFile)
 
-    selectedPropertiesList = [f'ATTRS(phys)=="{dev.phys}"'] # Make an udev rule matching the device file
+    selectedPropertiesList = [f'ATTRS{{phys}}=="{dev.phys}"'] # Make an udev rule matching the device file
     symlink_name = "/dev/" + deviceName
 
     # create udevrule

--- a/keebie.py
+++ b/keebie.py
@@ -260,25 +260,25 @@ class macroDevice():
 
         jsonData = readJson(deviceJson, deviceDir) # Cache the data held in the device json file
         self.initialLayer = jsonData["initial_layer"] # Layer for the device the start on
-        self.eventFile = "/dev/input/" + jsonData["event"] # The input event file
-        self.udevTests = jsonData["udev_tests"] # Strings for udev matching
+        self.eventFile = jsonData["devFile"]    # The input event file that was symlinked by the udev rule
+        self.udevMatchKeys = jsonData["udev_match_keys"] # Strings for udev matching
 
         self.currentLayer = self.initialLayer # Layer this device is currently on
         self.ledger = keyLedger(self.name) # A keyLedger to track input events on his devicet
         self.device = None # will be an InputEvent instance
 
-    def addUdevRule(self, priority = 85):
+    def addUdevRule(self, current_event_file = "", priority = 85):
         """Generate a udev rule for this device."""
-        path = f"{priority}-keebie-{self.name}.rules" # Name of the file for the rule
-        rule = ""
+        filepath = f"{priority}-keebie-{self.name}.rules" # Name of the file for the rule
+        rule_string = ""
 
-        for test in self.udevTests: # For all the udev tests
-            rule += test + ", " # Add them together with commas
-            dprint(rule)
+        for test in self.udevMatchKeys: # For all the udev tests
+            rule_string += test + ", " # Add them together with commas
+            dprint(rule_string)
 
-        writeJson(self.name + ".json", {"udev_rule": path}, deviceDir) # Save the udev rule filepath for removeDevice()
+        writeJson(self.name + ".json", {"udev_rule": filepath}, deviceDir) # Save the udev rule filepath for removeDevice()
 
-        subprocess.run(["sudo", "sh", installDataDir + "/setup_tools/udevRule.sh", rule, path]) # Run the udev setup script with sudo
+        subprocess.run(["sudo", "sh", installDataDir + "/setup_tools/udevRule.sh", rule_string, self.eventFile, filepath, current_event_file]) # Run the udev setup script with sudo
         
         subprocess.run(["sudo", "udevadm", "test", "/sys/class/input/event3"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) # Force udev to parse the new rule for the device
 
@@ -970,6 +970,10 @@ def newDevice(eventPath = "/dev/input/"):
     """Add a new json file to devices/."""
     print("Setting up device")
 
+    deviceName = input("Please provide a name for this device.\nThis name will be used to create a symlink to the device in /dev/<devicename> so choose something unique.\nName: ").strip()
+    while deviceName == "":
+        deviceName = input("Name cannot be empty. Name: ").strip()
+
     initialLayer = input("Please provide a name for for this devices initial layer (non-existent layers will be created, default.json by default): ") # Prompt the user for a layer filename
 
     if initialLayer.strip() == "": # If the user did not provide a layer name
@@ -979,21 +983,26 @@ def newDevice(eventPath = "/dev/input/"):
         createLayer(initialLayer) # Create it
 
     eventFile = detectKeyboard(eventPath) # Prompt the user for a device
-    eventFile = os.path.basename(eventFile) # Get the devices filename from its filepath
+    # eventFile = os.path.basename(eventFile) # Get the devices filename from its filepath
 
     input("\nA udev rule will be made next, sudo may prompt you for a password. Press enter to continue...") # Ensure the stdin is empty
 
-    selectedPropertiesList = [f"KERNEL==\"{eventFile}\""] # Make an udev rule matching the device file
+    dev = InputDevice(eventFile)
+
+    selectedPropertiesList = [f'ATTRS(phys)=="{dev.phys}"'] # Make an udev rule matching the device file
+    symlink_name = "/dev/" + deviceName
+
+    # create udevrule
 
     deviceJsonDict = { # Construct the device data dict
         "initial_layer": initialLayer,
-        "event": eventFile,
-        "udev_tests": selectedPropertiesList,
+        "devFile": symlink_name,
+        "udev_match_keys": selectedPropertiesList
     }
 
-    writeJson(eventFile + ".json", deviceJsonDict, deviceDir) # Write device data into a json file
+    writeJson(deviceName + ".json", deviceJsonDict, deviceDir) # Write device data into a json file
 
-    macroDevice(eventFile + ".json").addUdevRule() # Create a mcro device and make a udev rule, the user will be prompted for sudo
+    macroDevice(deviceName + ".json").addUdevRule(eventFile) # Create a mcro device and make a udev rule, the user will be prompted for sudo
 
     end()
 

--- a/makefile
+++ b/makefile
@@ -2,6 +2,7 @@ SHELL=/bin/bash
 
 bin_path="/usr/bin/keebie"
 install_path="/usr/share/keebie/"
+service_path="${HOME}/.config/systemd/user/keebie.service"
 
 pkg_type="tar"
 
@@ -62,6 +63,8 @@ install:
 	sudo cp -rv -t $(install_path)/data/ ./layers/ ./settings.json ./devices/ ./scripts/
 	sudo cp -rv -t $(install_path)/ ./setup_tools/
 
+	cp ./setup_tools/keebie.service "$(service_path)"
+
 	# sudo ./packaging/postinst
 	
 	@echo "keebie has been installed, please ensure you have the following packages:"
@@ -71,4 +74,5 @@ install:
 remove:
 	# sudo ./packaging/prerm
 	sudo rm -rfv $(bin_path) $(install_path)
+	rm "$(service_path)"
 	# sudo ./packaging/postrm

--- a/setup_tools/keebie.service
+++ b/setup_tools/keebie.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=Keebie service 
+
 [Service]
 Type=simple
 Environment=DISPLAY=:0
 Environment=XAUTHORITY=/home/$USER/.Xauthority
-ExecStart=/usr/bin/python3 <locaion of keebie.py>
+ExecStart=/usr/bin/keebie
+
 [Install]
 WantedBy=multi-user.target

--- a/setup_tools/udevRule.sh
+++ b/setup_tools/udevRule.sh
@@ -5,10 +5,32 @@
 # find the values vendor-id and product-id by using lsusb command
 # Note make sure you copy keebie.service to /etc/systemd/system before executing this script as sudo
 
-touch /etc/udev/rules.d/"$2"
+a=false
+for i in "$1" "$2" "$3" ; do
+    # debug echo
+    echo "$i"
+    if [[ "$i" == "" ]]; then
+        a=true
+    fi
+done
+if $a ; then
+    echo "Not enough arguments, exiting..."
+    exit -1
+fi
+
+rule_string="$1"
+symlink_file=$(basename "$2")
+udev_rule_file="$3"
+
+touch /etc/udev/rules.d/"$3"
 cd /etc/udev/rules.d/
 
-echo 'SUBSYSTEM=="input", '"$1"'MODE="0666", ENV{SYSTEMD_WANTS}="keebie.service"  TAG+="systemd"' > "$2"
+printf 'SUBSYSTEM=="input", %s MODE="0666", ENV{SYSTEMD_WANTS}="keebie.service"  TAG+="systemd" SYMLINK+="%s"' "$rule_string" "$symlink_file" > "$udev_rule_file"
+
+if [[ "$4" != "" ]]; then
+    echo "Creating symlink for current session. Udev should create the symlink automatically on reboot"
+    ln -s "$4" "/dev/$symlink_file"
+fi
 
 sleep 1s
 

--- a/setup_tools/udevRule.sh
+++ b/setup_tools/udevRule.sh
@@ -25,7 +25,7 @@ udev_rule_file="$3"
 touch /etc/udev/rules.d/"$3"
 cd /etc/udev/rules.d/
 
-printf 'SUBSYSTEM=="input", %s MODE="0666", ENV{SYSTEMD_WANTS}="keebie.service"  TAG+="systemd" SYMLINK+="%s"' "$rule_string" "$symlink_file" > "$udev_rule_file"
+printf 'SUBSYSTEM=="input", %s MODE="0666", ENV{SYSTEMD_USER_WANTS}="keebie.service"  TAG+="systemd" SYMLINK+="%s"' "$rule_string" "$symlink_file" > "$udev_rule_file"
 
 if [[ "$4" != "" ]]; then
     echo "Creating symlink for current session. Udev should create the symlink automatically on reboot"


### PR DESCRIPTION
These changes should help with the problem, that the /dev/input/eventXX file for a device might be different after a reboot (see https://wiki.archlinux.org/title/Udev)

This issue was mentioned in #34 and @triplefox proposed steps on how to tackle this problem:
https://github.com/daisyUniverse/Keebie/issues/34#issuecomment-1065611392

Even though there might even be a way to do this without udev, I've stuck with it, as it's needed for the systemd service anyway.

The main idea is to prompt a user for a explicit device name (instead of using `event23` for example)
and then let udev create a symlink like `/dev/numpad -> /dev/input/eventXX` automatically on boot.
To do this, udev needs some way of identifying a device.
I've decided to use the `ATTRS(phys)` attribute.
The steps are now as follows:
1. User creates new device `keebie -n` and gets prompted for a name (f.e. `numpad1`)
2. The current event file is recognized as usual by pressing a key on the device (f.e. `/dev/input/event23`)
3. The `ATTRS(phys)` is read from that device (via evdev)
4. This attribute is used in the udev rule that will symlink the device to `/dev/numpad1`
    - A symlink is created for the current session so the user doesn't need to reboot

A configuration file looks now like this:
```json numpad.json
{
   "initial_layer": "default.json",
   "devFile": "/dev/numpad",
   "udev_match_keys": [
      "ATTRS(phys)==\"usb-0000:0a:00.3-2/input0\""
   ],
   "udev_rule": "85-keebie-numpad.rules"
}

```


I have not tested it much, but I will do so in the next few days. Still wanted to open the PR now for feedback.